### PR TITLE
Normalize license tokens when searching for license text

### DIFF
--- a/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
+++ b/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
@@ -33,6 +33,8 @@ import java.util.regex.Pattern;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spdx.library.InvalidSPDXAnalysisException;
@@ -659,6 +661,9 @@ public class LicenseCompareHelper {
 			while (tokenIndex < tokens.length && startWordCount < numberOfWords) {
 				String token = tokens[tokenIndex++].trim();
 				if (token.length() > 0) {
+					if (NORMALIZE_TOKENS.containsKey(token.toLowerCase())) {
+						token = NORMALIZE_TOKENS.get(token.toLowerCase());
+					}
 					patternBuilder.append(Pattern.quote(token));
 					patternBuilder.append("\\s*");
 					startWordCount++;
@@ -764,6 +769,77 @@ public class LicenseCompareHelper {
 		}
 		return compareTemplateOutputHandler.getDifferences();
 	}
+	
+	/**
+	 * Replace any <code>NORMALIZE_TOKENS</code> with their normalized form for searching via the <code>nonOptionalTextToStartPattern</code>
+	 * @param charPositions List that matches the starting char position of the normalized text to the 
+	 * start positions of the original list
+	 * @param licenseText text to be normalized
+	 * @return tokens
+	 * @throws IOException 
+	 */
+	private static String normalizeTokensForRegex(String licenseText, List<Pair<Integer, Integer>> charPositions) throws IOException {
+		StringBuilder result = new StringBuilder();
+		BufferedReader reader = null;
+		Pattern spaceSplitter = Pattern.compile("(.+?)\\s+");
+		try {
+			reader = new BufferedReader(new StringReader(licenseText));
+			int originalCurrentLinePosition = 0;
+			String line = reader.readLine();
+			while (line != null) {
+				int lineCharPosition = 0;
+				Matcher lineMatcher = spaceSplitter.matcher(line);
+				while (lineMatcher.find()) {
+					String token = lineMatcher.group(1).trim();
+					if (!token.isEmpty() && NORMALIZE_TOKENS.containsKey(token.toLowerCase())) {
+						// we need to replace with the normalized token
+						result.append(line.substring(lineCharPosition, lineMatcher.start(1)));
+						int normalizedPosition = result.length();
+						token = NORMALIZE_TOKENS.get(token.toLowerCase());
+						result.append(token);
+//						result.append(' ');
+						charPositions.add(new ImmutablePair<>(normalizedPosition, originalCurrentLinePosition + lineMatcher.start(1)));
+						charPositions.add(new ImmutablePair<>(result.length(), originalCurrentLinePosition + lineMatcher.end(1)));
+						lineCharPosition = lineMatcher.end(1);
+					}
+				}
+				result.append(line.substring(lineCharPosition));
+				originalCurrentLinePosition = originalCurrentLinePosition + line.length() + "\n".length();
+				line = reader.readLine();
+				if (line != null) {
+					result.append("\n");
+				}
+			}
+		} finally {
+			if (reader != null) {
+				try {
+					reader.close();
+				} catch (IOException e) {
+					// ignore
+				}
+			}
+		}
+		return result.toString();
+	}
+	
+	/**
+	 * @param position position in the normalized text
+	 * @param charPositions List that matches the starting char position of the normalized text to the 
+	 * start positions of the original list
+	 * @return char position of the original text
+	 */
+	private static int findOriginalStart(int position, List<Pair<Integer, Integer>> charPositions) {
+		if (charPositions == null || charPositions.isEmpty()) {
+			return position;
+		}
+		Pair<Integer, Integer> lastPair = charPositions.get(0);
+		int i = 1;
+		while (i < charPositions.size() && lastPair.getKey() < position) {
+			lastPair = charPositions.get(i);
+			i++;
+		}
+		return lastPair.getValue() + (position - lastPair.getKey());
+	}
 
 	/**
 	 * Detect if a text contains the provided standard license (perhaps along with other text)
@@ -787,12 +863,22 @@ public class LicenseCompareHelper {
 			return false;
 		}
 		Pattern licenseMatchPattern = nonOptionalTextToStartPattern(nonOptionalText, CROSS_REF_NUM_WORDS_MATCH);
-		String compareLicenseText = normalizeText(text);
+		List<Pair<Integer, Integer>> charPositions = new ArrayList<>();
+		String normalizedText = normalizeText(text);
+		String compareLicenseText;
+		try {
+			compareLicenseText = normalizeTokensForRegex(normalizedText, charPositions);
+		} catch (IOException e1) {
+			// Just use the straight normalized license text
+			compareLicenseText = normalizeText(text);
+			charPositions.add(new ImmutablePair<>(0, 0));
+		}
+		
 		Matcher matcher = licenseMatchPattern.matcher(compareLicenseText);
 		if(matcher.find()) {
-			startIndex = matcher.start();
-			endIndex = matcher.end();
-			String completeText = compareLicenseText.substring(startIndex, endIndex);
+			startIndex = findOriginalStart(matcher.start(), charPositions);
+			endIndex = findOriginalStart(matcher.end(), charPositions);
+			String completeText = normalizedText.substring(startIndex, endIndex);
 			try {
 				result = !isTextStandardLicense(license, completeText).isDifferenceFound();
 			} catch (SpdxCompareException e) {

--- a/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
+++ b/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
@@ -712,8 +712,7 @@ public class LicenseCompareHelperTest extends TestCase {
         SpdxListedLicense apache10 = ListedLicenses.getListedLicenses().getListedLicenseById("Apache-1.0");
         SpdxListedLicense apache20 = ListedLicenses.getListedLicenses().getListedLicenseById("Apache-2.0");
         String multiLicenseText = UnitTestHelper.fileToText(GPL_3_TEXT) + "\n\n----------\n\n" +
-                                  UnitTestHelper.fileToText(APACHE_1_0_TEXT);
-
+                                  apache10.getLicenseText();
         assertTrue(LicenseCompareHelper.isStandardLicenseWithinText(multiLicenseText, gpl30));
         assertTrue(LicenseCompareHelper.isStandardLicenseWithinText(multiLicenseText, apache10));
         assertFalse(LicenseCompareHelper.isStandardLicenseWithinText(multiLicenseText, apache20));


### PR DESCRIPTION
There were 2 issues causing the tests to fail:

1. The GPL license text being compared had a copyright symbol rather than "(c)" used in the standard license text
2. The Apache 1.0 license text has a missing word on line 11:

`The "Apache" and "Apache Software Foundation" ` in the test file
`The name "Apache" and "Apache Software Foundation" ` in the license text

For 1., this PR adds code to normalize the tokens in the license text.  This will allow the license to be found if any of the legal team equivalent words are used.

For 2., I just changed the test.  The license template has the text difference marked as variable text, so if it was standalone it could match.  However, when search for the start of the text the regex uses just the standard text from the license and doesn't take into account the variable text.  It would be possible replace the variable text with the correct regex, but I'm not sure that would be needed in practice.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>